### PR TITLE
clean up answers and add answer ranking scores

### DIFF
--- a/index.js
+++ b/index.js
@@ -276,9 +276,13 @@ connectMongoDB( () => { if ( !mongodb || !config.mongo ) console.log( 'No MongoD
 
                             // update ranking info
                             if ( 'ranking' in setData && setData[ 'ranking' ][ questionId ] ) {
-                              for ( rankedAnsHash in setData[ 'ranking' ][ questionId ] ) {
-                                if ( !( rankedAnsHash in answerData[ 'entries' ] ) ) continue;
-                                answerData[ 'entries' ][ rankedAnsHash ][ 'ranked_by' ][ userInfo.username ] = true;
+                              const userRankings = setData[ 'ranking' ][ questionId ];
+                              for ( rankedAnsHash in userRankings ) {
+                                if ( !( rankedAnsHash in answerData.entries ) ) continue;
+                                const maxRanking = Math.max( ...Object.values( userRankings ) );
+                                // normalize the ranking to deal with different number of ranked answers
+                                answerData.entries[ rankedAnsHash ][ 'ranked_by' ][ userInfo.username ] =
+                                    userRankings[ ansId ] / maxRanking;
                               }
                             }
 


### PR DESCRIPTION
* add `authors` field as a dictionary for each answer in the `answers_<question_id>` documents. A write to the user's document will:
  - add him/her to the `authors` dictionary of his/her answer (identified by the answer hash) for the question identified by `<question_id>`
  - remove him/her from the `authors` dictionary of all other answers for the question identified by `<question_id>`
  - delete any answers for `<question_id>` without any associated authors
* store a normalized ranking score (instead of just `bool`) for each author in the `ranked_by` field for each answer
* resolves #13 